### PR TITLE
Fix various syntax issues.

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,15 +1,22 @@
 #+TITLE:(#| TMPL_VAR name |#)
-#+SUBTITLE: What (#| TMPL_VAR name |#) is.
+
+*What (#| TMPL_VAR name |#) is.*
 
 (#| TMPL_VAR name |#) does...
 
 * Getting started
-Clone the git repository:
+Clone the Git repository:
 #+begin_src sh
-  git clone --recursive https://github.com/atlas-engineer/(#| TMPL_VAR name |#)
+  git clone --recursive https://github.com/atlas-engineer/(#| TMPL_VAR name |#) ~/common-lisp/
 #+end_src
 
-* API
+* Examples
+
+#+begin_src lisp
+  ; Basic example here, see more in package.lisp.
+#+end_src
+
 * How it works
-* To-Dos
+
+* Roadmap
 - [ ]

--- a/package.lisp
+++ b/package.lisp
@@ -1,6 +1,6 @@
 ;;;; SPDX-FileCopyrightText: (#| TMPL_VAR author |#)
 ;;;; SPDX-License-Identifier: (#| TMPL_VAR license |#)
 
-(defpackage #:(#| TMPL_VAR name |#)
-  (:use #:cl)
+(uiop:define-package #:(#| TMPL_VAR name |#)
+  (:use #:common-lisp)
   (:documentation "Describe `(#| TMPL_VAR name |#)' package here"))

--- a/system.asd
+++ b/system.asd
@@ -5,7 +5,8 @@
   :description "Describe (#| TMPL_VAR name |#) here"
   :author "(#| TMPL_VAR author |#)"
   :license  "(#| TMPL_VAR license |#)"
-  :version "0.0.0"(#| TMPL_IF depends-on |#)
+  :version "0.0.0"
+  :in-order-to ((test-op (test-op "(#| TMPL_VAR name |#)/tests")))(#| TMPL_IF depends-on |#)
   :depends-on (#| TMPL_VAR dependencies-string |#)(#| /TMPL_IF |#)
   :serial t
   :components ((:file "package")
@@ -14,10 +15,10 @@
 (defsystem "(#| TMPL_VAR name |#)/tests"
   :depends-on ((#| TMPL_VAR name |#) lisp-unit2)
   :serial t
-  :components ((:file "tests/package")
-               (:file "tests/tests"))
+  :pathname "tests/"
+  :components ((:file "package")
+               (:file "tests"))
   :perform (test-op (o c)
                     (symbol-call :lisp-unit2 :run-tests
                                  :package :(#| TMPL_VAR name |#)/tests
-                                 :run-contexts (symbol-function
-                                                (read-from-string "lisp-unit2:with-summary-context")))))
+                                 :run-contexts (find-symbol "WITH-SUMMARY-CONTEXT" :lisp-unit2))))

--- a/system.asd
+++ b/system.asd
@@ -4,6 +4,7 @@
 (defsystem "(#| TMPL_VAR name |#)"
   :description "Describe (#| TMPL_VAR name |#) here"
   :author "(#| TMPL_VAR author |#)"
+  :homepage "https://github.com/atlas-engineer/(#| TMPL_VAR name |#)"
   :license  "(#| TMPL_VAR license |#)"
   :version "0.0.0"
   :in-order-to ((test-op (test-op "(#| TMPL_VAR name |#)/tests")))(#| TMPL_IF depends-on |#)

--- a/system.asd
+++ b/system.asd
@@ -1,13 +1,13 @@
 ;;;; SPDX-FileCopyrightText: (#| TMPL_VAR author |#)
 ;;;; SPDX-License-Identifier: (#| TMPL_VAR license |#)
 
-(asdf:defsystem #:(#| TMPL_VAR name |#)
+(defsystem "(#| TMPL_VAR name |#)"
   :description "Describe (#| TMPL_VAR name |#) here"
   :author "(#| TMPL_VAR author |#)"
   :license  "(#| TMPL_VAR license |#)"
-  :version "0.0.1"
-  :serial t(#| TMPL_IF depends-on |#)
+  :version "0.0.0"(#| TMPL_IF depends-on |#)
   :depends-on (#| TMPL_VAR dependencies-string |#)(#| /TMPL_IF |#)
+  :serial t
   :components ((:file "package")
                (:file "(#| TMPL_VAR name |#)")))
 

--- a/tests/package.lisp
+++ b/tests/package.lisp
@@ -1,5 +1,5 @@
 ;;;; SPDX-FileCopyrightText: (#| TMPL_VAR author |#)
 ;;;; SPDX-License-Identifier: (#| TMPL_VAR license |#)
 
-(uiop:define-package (#| TMPL_VAR name |#)/tests
-  (:use #:cl #:lisp-unit2))
+(uiop:define-package #:(#| TMPL_VAR name |#)/tests
+  (:use #:common-lisp #:lisp-unit2))


### PR DESCRIPTION
I've removed `#+SUBTITLE` because it does not display on GitHub (it only works for _some_ Org renderers, but not the default HTML renderer).

I've moved `serial t` next to `:components`, because it's about components.

I've remove `API` from the README because I believe it should be described in `package.lisp`.

What are we supposed to write in `How it works`?  Is it meant for example or for a brief introduction?  Maybe rename the section?  Or remove it?